### PR TITLE
New Search Features

### DIFF
--- a/src/tests/test_search_features.py
+++ b/src/tests/test_search_features.py
@@ -19,8 +19,8 @@ def main(term):
 	print(results2)
 
 	cat = results2[0]
-	print '\nTest find_related_articles for:', cat
-	results3 = wiki.find_related_articles(cat)
+	print '\nTest find_related_titles for:', cat
+	results3 = wiki.find_related_titles(cat)
 	print(results3)
 
 

--- a/src/tests/test_search_features.py
+++ b/src/tests/test_search_features.py
@@ -1,0 +1,29 @@
+from wikiapi import WikiApi
+
+def main(term):
+	wiki = WikiApi()
+
+	print 'Old find for:',term
+	results = wiki.find(term)
+	print(len(results))
+	print(results)
+
+	print '\nTest find_titles for:',term
+	results1 = wiki.find_titles(term)
+	print(len(results1))
+	print(results1)
+
+	title = results1[0]
+	print '\nTest find_related_categories for:', title
+	results2 = wiki.find_related_categories(title)
+	print(results2)
+
+	cat = results2[0]
+	print '\nTest find_related_articles for:', cat
+	results3 = wiki.find_related_articles(cat)
+	print(results3)
+
+
+if __name__ == "__main__":
+	term = 'einstein'
+	main(term)

--- a/src/tests/test_search_features.py
+++ b/src/tests/test_search_features.py
@@ -3,14 +3,12 @@ from wikiapi import WikiApi
 def main(term):
 	wiki = WikiApi()
 
-	print 'Old find for:',term
-	results = wiki.find(term)
-	print(len(results))
-	print(results)
+	# print 'Old find for:',term
+	# results = wiki.find(term)
+	# print results,'\n'
 
-	print '\nTest find_titles for:',term
+	print 'Test find_titles for:',term
 	results1 = wiki.find_titles(term)
-	print(len(results1))
 	print(results1)
 
 	title = results1[0]

--- a/src/wikiapi/wikiapi.py
+++ b/src/wikiapi/wikiapi.py
@@ -129,7 +129,7 @@ class WikiApi(object):
             results.append(cat)
         return results
 
-    def find_related_articles(self,category,limit='10'):
+    def find_related_titles(self,category,limit='10'):
         # search articles from category
         # API doc : https://www.mediawiki.org/wiki/API:Query
         search_params = {

--- a/src/wikiapi/wikiapi.py
+++ b/src/wikiapi/wikiapi.py
@@ -68,12 +68,13 @@ class WikiApi(object):
             results.append(slug[0])
         return results
 
-    def find_titles(self, terms):
+    def find_titles(self, terms,limit='10'):
+        # API doc : https://www.mediawiki.org/wiki/API:Search
         search_params = {
-            'action': 'query', #'opensearch',
-            'srinfo': 'suggestion',
+            'action': 'query',
             'list': 'search',
             'srsearch': terms,
+            'srlimit': limit,
             'format': 'xml'
         }
 
@@ -93,13 +94,13 @@ class WikiApi(object):
         results = []
         for item in items:
             title = item.attributes['title'].value
-            title = (title.replace(' ','_')).encode('UTF-8')
+            title = title.replace(' ','_')
             results.append(title)
         return results
 
     def find_related_categories(self,title,limit='10'):
         # search related categories
-
+        # API doc : https://www.mediawiki.org/wiki/API:Query
         search_params = {
             'action': 'query',
             'titles': title,
@@ -124,13 +125,13 @@ class WikiApi(object):
         results = []
         for item in items:
             cat = item.attributes['title'].value
-            cat = (cat.replace(' ','_')).encode('UTF-8')
+            cat = cat.replace(' ','_')
             results.append(cat)
         return results
 
-    def find_related_articles(self,category,limit='5'):
+    def find_related_articles(self,category,limit='10'):
         # search articles from category
-
+        # API doc : https://www.mediawiki.org/wiki/API:Query
         search_params = {
             'action': 'query',
             'list': 'categorymembers',
@@ -154,7 +155,7 @@ class WikiApi(object):
         results = []
         for item in items:
             title = item.attributes['title'].value
-            title = (title.replace(' ','_')).encode('UTF-8')
+            title = title.replace(' ','_')
             results.append(title)
         return results
 

--- a/src/wikiapi/wikiapi.py
+++ b/src/wikiapi/wikiapi.py
@@ -97,6 +97,36 @@ class WikiApi(object):
             results.append(title)
         return results
 
+    def find_related_categories(self,title,limit='10'):
+        # search related categories
+
+        search_params = {
+            'action': 'query',
+            'titles': title,
+            'prop': 'categories',
+            'cllimit': limit,
+            'format': 'xml'
+        }
+
+        url = "{scheme}://{locale_sub}.{hostname_path}".format(
+            scheme=uri_scheme,
+            locale_sub=self.options['locale'],
+            hostname_path=api_uri
+        )
+        resp = self.get(url, search_params)
+
+        # parse search results
+        xmldoc = minidom.parseString(resp)
+        items = xmldoc.getElementsByTagName('cl')
+
+        # return results as wiki page titles
+        results = []
+        for item in items:
+            cat = item.attributes['title'].value
+            cat = (cat.replace(' ','_')).encode('UTF-8')
+            results.append(cat)
+        return results
+
     def get_article(self, title):
         url = '{scheme}://{locale_sub}.{hostname_path}{article_title}'.format(
             scheme=uri_scheme,

--- a/src/wikiapi/wikiapi.py
+++ b/src/wikiapi/wikiapi.py
@@ -105,6 +105,7 @@ class WikiApi(object):
             'titles': title,
             'prop': 'categories',
             'cllimit': limit,
+            'clshow': '!hidden',
             'format': 'xml'
         }
 
@@ -133,7 +134,7 @@ class WikiApi(object):
         search_params = {
             'action': 'query',
             'list': 'categorymembers',
-            'cmtitle': category, #('Category:' + category),
+            'cmtitle': category,
             'cmlimit': limit,
             'format': 'xml'
         }

--- a/src/wikiapi/wikiapi.py
+++ b/src/wikiapi/wikiapi.py
@@ -68,6 +68,35 @@ class WikiApi(object):
             results.append(slug[0])
         return results
 
+    def find_titles(self, terms):
+        search_params = {
+            'action': 'query', #'opensearch',
+            'srinfo': 'suggestion',
+            'list': 'search',
+            'srsearch': terms,
+            'format': 'xml'
+        }
+
+        url = "{scheme}://{locale_sub}.{hostname_path}".format(
+            scheme=uri_scheme,
+            locale_sub=self.options['locale'],
+            hostname_path=api_uri
+        )
+        resp = self.get(url, search_params)
+        logger.debug('find "%s" response: %s', terms, resp)
+
+        # parse search results
+        xmldoc = minidom.parseString(resp)
+        items = xmldoc.getElementsByTagName('p')
+
+        # return results as wiki page titles
+        results = []
+        for item in items:
+            title = item.attributes['title'].value
+            title = (title.replace(' ','_')).encode('UTF-8')
+            results.append(title)
+        return results
+
     def get_article(self, title):
         url = '{scheme}://{locale_sub}.{hostname_path}{article_title}'.format(
             scheme=uri_scheme,

--- a/src/wikiapi/wikiapi.py
+++ b/src/wikiapi/wikiapi.py
@@ -127,6 +127,36 @@ class WikiApi(object):
             results.append(cat)
         return results
 
+    def find_related_articles(self,category,limit='5'):
+        # search articles from category
+
+        search_params = {
+            'action': 'query',
+            'list': 'categorymembers',
+            'cmtitle': category, #('Category:' + category),
+            'cmlimit': limit,
+            'format': 'xml'
+        }
+
+        url = "{scheme}://{locale_sub}.{hostname_path}".format(
+            scheme=uri_scheme,
+            locale_sub=self.options['locale'],
+            hostname_path=api_uri
+        )
+        resp = self.get(url, search_params)
+
+        # parse search results
+        xmldoc = minidom.parseString(resp)
+        items = xmldoc.getElementsByTagName('cm')
+
+        # return results as wiki page titles
+        results = []
+        for item in items:
+            title = item.attributes['title'].value
+            title = (title.replace(' ','_')).encode('UTF-8')
+            results.append(title)
+        return results
+
     def get_article(self, title):
         url = '{scheme}://{locale_sub}.{hostname_path}{article_title}'.format(
             scheme=uri_scheme,


### PR DESCRIPTION
This PR adds a few features provided by MediaWiki API.

- Added `find_titles` to replace the `find` method, because the latter one uses MediaWiki's Opensearch module which seems deprecated. `find_titles` uses the Search API instead.

- Added `find_related_categories` which retrieves the categories of a Wikipedia page (given the title).

- Added `find_related_titles` which retrieves Wikipedia pages corresponding to a category.

- All these methods have an optional `limit` argument (string) to set the number of results desired.

- Some examples are provided in the file `src/tests/test_search_features.py`.