### PR TITLE
Silence BeautifulSoup warning

### DIFF
--- a/src/wikiapi/wikiapi.py
+++ b/src/wikiapi/wikiapi.py
@@ -119,7 +119,7 @@ class WikiApi(object):
 
     @staticmethod
     def _strip_html(text):  # pragma: no cover
-        return BeautifulSoup(text).text
+        return BeautifulSoup(text, 'lxml').text
 
     def get_relevant_article(self, results, keywords):
         """


### PR DESCRIPTION
Use 'lxml' rather than 'html.parser', since it is recommended by the
BeautifulSoup authors (faster, more lenient on a wider variety of Python
versions). Fixes #14.